### PR TITLE
fix: escape dom text to prevent xss attack

### DIFF
--- a/src/assets/js/typewriterEffect.ts
+++ b/src/assets/js/typewriterEffect.ts
@@ -1,3 +1,5 @@
+const characterEscape = (character) => `&#${character.charCodeAt(0)};`;
+
 const typewriterEffect = (destination: HTMLElement, callback?: () => any, speed = 100): void => {
   const dialogTexts = JSON.parse(destination.getAttribute('data-text') ?? '');
   const totalNumberOfLines = dialogTexts.length;
@@ -13,7 +15,7 @@ const typewriterEffect = (destination: HTMLElement, callback?: () => any, speed 
     }
 
     // Append character
-    currentParagraph.innerHTML += dialogTexts[currentLine][currentTextPosition];
+    currentParagraph.innerHTML += characterEscape(dialogTexts[currentLine][currentTextPosition]);
     currentTextPosition++;
 
     // Go to next line if current line is fully displayed


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
Escape text retrieved from `data-text` attribute used in typewriter effect. Solve #3. 

## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
1. Check the typewriter effect

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [ ] New feature - `feat`
- [x] Bug fix - `fix`
- [ ] Refactor - `refactor`
- [ ] Test - `test`
- [ ] Other(s): <!-- Fill the type of changes here -->

## Remarks
<!---- Leave your remarks if applicable ---->
N/A
