### PR TITLE
fix: refine csp rules for google analytics

### DIFF
--- a/src/index.pug
+++ b/src/index.pug
@@ -8,7 +8,7 @@ html(xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en")
     meta(name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover")
     meta(name="format-detection" content="telephone=no, date=no, address=no, email=no")
     meta(name="msapplication-tap-highlight" content="no")
-    meta(http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'nonce-%APP_NONCE%' www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://www.google-analytics.com www.google-analytics.com https://stats.g.doubleclick.net; font-src 'self'; connect-src 'self' https://www.google-analytics.com www.google-analytics.com https://stats.g.doubleclick.net")
+    meta(http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'nonce-%APP_NONCE%' www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://www.google-analytics.com www.google-analytics.com https://stats.g.doubleclick.net https://www.google.com; font-src 'self'; connect-src 'self' https://www.google-analytics.com www.google-analytics.com https://stats.g.doubleclick.net")
 
     //- SEO
     include ./partials/seo.pug


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
Refine Content Security Policy rules to allow Google Analytics display images under https://google.com.

## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
N/A

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [ ] New feature - `feat`
- [x] Bug fix - `fix`
- [ ] Refactor - `refactor`
- [ ] Test - `test`
- [ ] Other(s): <!-- Fill the type of changes here -->

## Remarks
<!---- Leave your remarks if applicable ---->
N/A
